### PR TITLE
Change EventStore Client API package to EventStore.ClientAPI v5.0.5

### DIFF
--- a/src/protobufSnapshotting/protobufSnapshotting.csproj
+++ b/src/protobufSnapshotting/protobufSnapshotting.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CorshamScience.MessageDispatch.Core" Version="2.0.0" />
-    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.1.0.23" />
+    <PackageReference Include="EventStore.Client" Version="5.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
# Changes
 - Removed `EventStore.ClientAPI.NetCore`
 - Added `EventStore.ClientAPI` version 5.0.5 (same as MessageDispatch.EventStore)