### PR TITLE
Add IntervalSnapshotStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A package that provides a composable `IDispatcher<ResolvedEvent>` that can be us
 Included:
 
 - `ISnapshotStrategy` - an interface that can be implemented to define when a snapshot should be recorded by the dispatcher
-  - `OnceDailySnapshotStrategy` and `NamedEventSnapshotStrategy` are provided as ready made implementations
+  - `IntervalSnapshotStrategy`, `OnceDailySnapshotStrategy`, and `NamedEventSnapshotStrategy` are provided as ready made implementations
 - `IStateProvider` - an interface that should be implemented by a class that provides the current state that should be persisted when a snapshot is recorded
 - `IStateSnapshotter` - an interface that can be implemented to define how to save and load snapshots
   - `ProtoBufStateSnapshotter` and `JsonSerialisingFileStateSnapshotter` are provided as ready made implementations

--- a/src/MessageDispatch.Snapshotting.Core.Tests/IntervalSnapshotStrategyTests.cs
+++ b/src/MessageDispatch.Snapshotting.Core.Tests/IntervalSnapshotStrategyTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Pharmaxo. All rights reserved.
+
+using PharmaxoScientific.MessageDispatch.Snapshotting.Core;
+
+namespace MessageDispatch.Snapshotting.Core.Tests;
+
+public class IntervalSnapshotStrategyTests
+{
+    private static readonly List<TimeSpan> _timeSpanValues =
+    [
+        new(1, 0, 0, 0),
+        new(0, 1, 0, 0),
+        new(0, 0, 1, 0)
+    ];
+
+    [TestCaseSource(nameof(_timeSpanValues))]
+    public void ShouldSnapshotForEvent_GivenFirstEvent_ReturnsFalse(TimeSpan timeSpan)
+    {
+        var strategy = new IntervalSnapshotStrategy<object>(timeSpan);
+        var resolvedEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 0);
+
+        Clock.Initialize(() => DateTime.UtcNow);
+
+        Assert.That(strategy.ShouldSnapshotForEvent(resolvedEvent), Is.False);
+    }
+
+    [TestCaseSource(nameof(_timeSpanValues))]
+    public void ShouldSnapshotForEvent_GivenTwoEventsWithinInterval_ReturnsFalse(TimeSpan timeSpan)
+    {
+        var strategy = new IntervalSnapshotStrategy<object>(timeSpan);
+
+        var firstEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 0);
+        var secondEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 1);
+
+        var now = DateTime.UtcNow;
+        Clock.Initialize(() => now);
+
+        strategy.ShouldSnapshotForEvent(firstEvent);
+
+        Clock.Initialize(() => now + timeSpan - TimeSpan.FromSeconds(1));
+
+        Assert.That(strategy.ShouldSnapshotForEvent(secondEvent), Is.False);
+    }
+
+    [TestCaseSource(nameof(_timeSpanValues))]
+    public void ShouldSnapshotForEvent_GivenEventAfterIntervalElapsed_ReturnsTrue(TimeSpan timeSpan)
+    {
+        var strategy = new IntervalSnapshotStrategy<object>(timeSpan);
+
+        var firstEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 0);
+        var secondEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 1);
+
+        var now = DateTime.UtcNow;
+        Clock.Initialize(() => now);
+
+        strategy.ShouldSnapshotForEvent(firstEvent);
+
+        Clock.Initialize(() => now +  timeSpan);
+
+        Assert.That(strategy.ShouldSnapshotForEvent(secondEvent), Is.True);
+    }
+
+    [TestCaseSource(nameof(_timeSpanValues))]
+    public void ShouldSnapshotForEvent_GivenMultipleIntervalsElapsed_ReturnsTrue(TimeSpan timeSpan)
+    {
+        var strategy = new IntervalSnapshotStrategy<object>(timeSpan);
+
+        var firstEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 0);
+        var secondEvent = TestHelpers.BuildResolvedEvent("AnyEventType", 1);
+
+        var now = DateTime.UtcNow;
+        Clock.Initialize(() => now);
+
+        strategy.ShouldSnapshotForEvent(firstEvent);
+
+        Clock.Initialize(() => now +  timeSpan + timeSpan);
+
+        Assert.That(strategy.ShouldSnapshotForEvent(secondEvent), Is.True);
+    }
+}

--- a/src/MessageDispatch.Snapshotting.Core.Tests/IntervalSnapshotStrategyTests.cs
+++ b/src/MessageDispatch.Snapshotting.Core.Tests/IntervalSnapshotStrategyTests.cs
@@ -55,7 +55,7 @@ public class IntervalSnapshotStrategyTests
 
         strategy.ShouldSnapshotForEvent(firstEvent);
 
-        Clock.Initialize(() => now +  timeSpan);
+        Clock.Initialize(() => now + timeSpan);
 
         Assert.That(strategy.ShouldSnapshotForEvent(secondEvent), Is.True);
     }
@@ -73,7 +73,7 @@ public class IntervalSnapshotStrategyTests
 
         strategy.ShouldSnapshotForEvent(firstEvent);
 
-        Clock.Initialize(() => now +  timeSpan + timeSpan);
+        Clock.Initialize(() => now + timeSpan + timeSpan);
 
         Assert.That(strategy.ShouldSnapshotForEvent(secondEvent), Is.True);
     }

--- a/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
+++ b/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
@@ -18,7 +18,7 @@ public class IntervalSnapshotStrategy<T> : ISnapshotStrategy<T>
     /// <summary>
     /// Initialises a new instance of the <see cref="IntervalSnapshotStrategy{TState}"/>.
     /// </summary>
-    /// <param name="interval"></param>
+    /// <param name="interval">The interval that snapshots should be recorded on.</param>
     public IntervalSnapshotStrategy(TimeSpan interval)
     {
         if (interval <= TimeSpan.Zero)

--- a/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
+++ b/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
@@ -40,7 +40,8 @@ public class IntervalSnapshotStrategy<T> : ISnapshotStrategy<T>
             return false;
         }
 
-        if (now - _lastSnapshotTime.Value < _interval)
+        var elapsed = now - _lastSnapshotTime.Value;
+        if (elapsed < _interval)
         {
             return false;
         }

--- a/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
+++ b/src/MessageDispatch.Snapshotting.Core/IntervalSnapshotStrategy.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Pharmaxo. All rights reserved.
+
+using System;
+
+namespace PharmaxoScientific.MessageDispatch.Snapshotting.Core;
+
+/// <summary>
+/// An implementation of the <see cref="ISnapshotStrategy{T}"/>
+/// that returns true when a configured time interval has elapsed
+/// since the last written snapshot.
+/// </summary>
+/// <typeparam name="T">The type of the event (unused in this strategy).</typeparam>
+public class IntervalSnapshotStrategy<T> : ISnapshotStrategy<T>
+{
+    private readonly TimeSpan _interval;
+    private DateTime? _lastSnapshotTime;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="IntervalSnapshotStrategy{TState}"/>.
+    /// </summary>
+    /// <param name="interval"></param>
+    public IntervalSnapshotStrategy(TimeSpan interval)
+    {
+        if (interval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(interval));
+        }
+
+        _interval = interval;
+    }
+
+    /// <inheritdoc />
+    public bool ShouldSnapshotForEvent(T @event)
+    {
+        var now = Clock.Now;
+
+        if (!_lastSnapshotTime.HasValue)
+        {
+            _lastSnapshotTime = now;
+            return false;
+        }
+
+        if (now - _lastSnapshotTime.Value < _interval)
+        {
+            return false;
+        }
+
+        _lastSnapshotTime = now;
+        return true;
+    }
+}

--- a/src/MessageDispatch.Snapshotting.Core/OnceDailySnapshotStrategy.cs
+++ b/src/MessageDispatch.Snapshotting.Core/OnceDailySnapshotStrategy.cs
@@ -9,27 +9,12 @@ namespace PharmaxoScientific.MessageDispatch.Snapshotting.Core;
 /// that returns true if the last written snapshot was on the previous day.
 /// </summary>
 /// <typeparam name="T">The type of the event (unused in this strategy).</typeparam>
-public class OnceDailySnapshotStrategy<T> : ISnapshotStrategy<T>
+public class OnceDailySnapshotStrategy<T> : IntervalSnapshotStrategy<T>
 {
-    private DateTime? _lastSnapshotTime;
-
-    /// <inheritdoc />
-    public bool ShouldSnapshotForEvent(T @event)
+    /// <summary>
+    /// Initialises a new instance of the <see cref="OnceDailySnapshotStrategy{TState}"/>.
+    /// </summary>
+    public OnceDailySnapshotStrategy() : base(TimeSpan.FromDays(1))
     {
-        var now = Clock.Now;
-
-        if (!_lastSnapshotTime.HasValue)
-        {
-            _lastSnapshotTime = now;
-            return false;
-        }
-
-        if (now.Date <= _lastSnapshotTime.Value.Date)
-        {
-            return false;
-        }
-
-        _lastSnapshotTime = now;
-        return true;
     }
 }


### PR DESCRIPTION
# Add IntervalSnapshotStrategy

This pull request adds a third `SnapshotStrategy` that enables snapshots to be written on a configurable schedule, rather than being restricted to once per day.